### PR TITLE
feat: expose global typography variables

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,8 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: `
-       @use "@styles/base/colors" as *;
+        @use "@styles/tokens/typography-primitives" as *;
+        @use "@styles/base/colors" as *;
         @use "@styles/base/typography" as *;
         @use "@styles/base/mixins" as *;
         @use "@styles/base/spacing" as *;


### PR DESCRIPTION
## Summary
- inject typography primitive tokens globally for all SCSS so variables like `$font-family-heading` are always available

## Testing
- `npm run lint` *(fails: Plugin "plugin:react" not found)*
- `npm run build` *(fails: Could not resolve "./FloatingIcons.scss" from "src/components/layout/Hero/Icons/Floating.jsx" )*

------
https://chatgpt.com/codex/tasks/task_e_688de788ce24832c805ef668f22b8cca